### PR TITLE
Correction: path reference to Generaldistribution module

### DIFF
--- a/distributions/Gaussiandistribution.py
+++ b/distributions/Gaussiandistribution.py
@@ -1,7 +1,7 @@
 import math
 import matplotlib.pyplot as plt
 
-from Generaldistribution import Distribution
+from .Generaldistribution import Distribution
 
 class Gaussian(Distribution):
     """ Gaussian distribution class for calculating and


### PR DESCRIPTION
When importing a module in a package, the dot (.) is used to specify the relative path or location of the module within the package. It helps to navigate through the package hierarchy and access the desired module.